### PR TITLE
23-country-flag-emojis-dont-work-on-chrome-edge 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "flightcoachscore",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "flightcoachscore",
-			"version": "0.0.2",
+			"version": "0.0.3",
 			"dependencies": {
 				"bootstrap": "^5.3.3",
 				"bootstrap-icons": "^1.11.3",
+				"country-flag-emoji-polyfill": "^0.1.8",
 				"file-saver": "^2.0.5",
 				"js-md5": "^0.8.3",
 				"jszip": "^3.10.1",
@@ -1786,6 +1787,12 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"license": "MIT"
+		},
+		"node_modules/country-flag-emoji-polyfill": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/country-flag-emoji-polyfill/-/country-flag-emoji-polyfill-0.1.8.tgz",
+			"integrity": "sha512-Mbah52sADS3gshUYhK5142gtUuJpHYOXlXtLFI3Ly4RqgkmPMvhX9kMZSTqDM8P7UqtSW99eHKFphhQSGXA3Cg==",
 			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 	"dependencies": {
 		"bootstrap": "^5.3.3",
 		"bootstrap-icons": "^1.11.3",
+		"country-flag-emoji-polyfill": "^0.1.8",
 		"file-saver": "^2.0.5",
 		"js-md5": "^0.8.3",
 		"jszip": "^3.10.1",

--- a/src/lib/components/leaderboards/DBTable.svelte
+++ b/src/lib/components/leaderboards/DBTable.svelte
@@ -65,6 +65,7 @@
 					<tr
 						class={row.flight_id == $activeFlight?.meta.flight_id ? 'table-active' : ''}
 						role="button"
+						style="font-family: 'Twemoji Country Flags', sans-serif !important" 
 						on:click={() => {
 							if (showID == row.flight_id) {
 								showID = undefined;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import 'bootstrap/dist/css/bootstrap.min.css';
 	import 'bootstrap/dist/js/bootstrap.min.js';
 	import 'bootstrap-icons/font/bootstrap-icons.css';
+	import { polyfillCountryFlagEmojis } from "country-flag-emoji-polyfill";
 
 	import MarkdownIt from 'markdown-it';
 	import MainNavBar from './MainNavBar.svelte';
@@ -14,6 +15,8 @@
 	import { loading, dev, help, windowHeight, windowWidth } from '$lib/stores/shared';
 
 
+	polyfillCountryFlagEmojis();
+	
 	const md = new MarkdownIt();
 
 	$: if ($page) {

--- a/src/routes/user/profile/+page.svelte
+++ b/src/routes/user/profile/+page.svelte
@@ -101,7 +101,7 @@
 			/>
 		</div>
 
-		<div class="mb-3">
+		<div class="mb-3" style="font-family: 'Twemoji Country Flags', sans-serif !important">
 			<label for="country" class="form-label">Country</label>
 			<select
 				class="form-select"

--- a/src/routes/user/register/+page.svelte
+++ b/src/routes/user/register/+page.svelte
@@ -83,7 +83,7 @@
 			<div id="passwordhelp" class="form-text">Minimum of ten characters</div>
 		</div>
 
-		<div class="mb-3">
+		<div class="mb-3" style="font-family: 'Twemoji Country Flags', sans-serif !important" >
 			<label for="country" class="form-label">Country</label>
 			<select class="form-select" id="country" name="country" required>
 				{#each countries as c}


### PR DESCRIPTION
Working on Firefox, Edge, Chrome on laptop.

Short of building a customised Bootstrap, the !important hack seems to be the best way.
